### PR TITLE
Added details to the paging per page documentation

### DIFF
--- a/source/documentation/cloud-apps/api-basics.md
+++ b/source/documentation/cloud-apps/api-basics.md
@@ -257,7 +257,7 @@ Spiceworks server.
 For paginated requests, you can request a specific page of results.  For some
 paginated requests, you can also specify the number of results per page.  To set
 these parameters pass them to the `request` function as keys in the final
-options argument. The default value for the per page attribute is 30, and only values between 1 and 100 are allowed.
+options argument. The default value for the `per_page` attribute is 30, and only integer values between 1 and 100 are allowed.
 
 For example, if you wanted the second page of currently open tickets with 50
 tickets per page you would write:

--- a/source/documentation/cloud-apps/api-basics.md
+++ b/source/documentation/cloud-apps/api-basics.md
@@ -257,7 +257,7 @@ Spiceworks server.
 For paginated requests, you can request a specific page of results.  For some
 paginated requests, you can also specify the number of results per page.  To set
 these parameters pass them to the `request` function as keys in the final
-options argument.
+options argument. The default value for the per page attribute is 30, and only values between 1 and 100 are allowed.
 
 For example, if you wanted the second page of currently open tickets with 50
 tickets per page you would write:


### PR DESCRIPTION
For per page docs, 30 is default, 1 is min and 100 is max,
added this info to docs.

@msgerbush This came up with a conversation with Bill Creager last week. He wanted a way to return all results in one page, which led me to look around the code and noticed you set 30 to default, 1 to min and 100 to max per page results. This I think, needs to be in the docs. 

Having limited him to 100 per_page results he now wants to know: "ask Michael what's the recommended way to loop through the pages...promises/a+ probably has some mechanism"

Let me know what you think. 