### PR TITLE
Adding documentation about Extended Data fields in the response

### DIFF
--- a/source/documentation/cloud-apps/api-basics.md
+++ b/source/documentation/cloud-apps/api-basics.md
@@ -275,7 +275,7 @@ request documentation for more information on the `per_page` defaults.
 When a paginated request is returned, it will always have a top-level `meta`
 attribute containing pagination information.  For example:
 
-```json
+```js
 "meta": {
   "total_entries": 205, // total number of items, across all pages
   "page_count": 7, // total number of pages

--- a/source/documentation/cloud-apps/reference/environment.md
+++ b/source/documentation/cloud-apps/reference/environment.md
@@ -110,7 +110,7 @@ Name | Type | Description
 
 Example user (note all arrays have been reduced to a single example item)
 
-```json
+```js
 {
   "id": 2,
   "first_name": "Lucy",

--- a/source/documentation/cloud-apps/reference/environment.md
+++ b/source/documentation/cloud-apps/reference/environment.md
@@ -23,7 +23,7 @@ card.onActivate(function(environment){
 ```
 
 ##### Response
-```json
+```js
 {
   "app_host":
     {
@@ -81,7 +81,7 @@ Name | Type | Description
 
 ##### Response
 
-```json
+```js
 {
   "meta": {
     "total_entries": 3,

--- a/source/documentation/cloud-apps/reference/environment.md
+++ b/source/documentation/cloud-apps/reference/environment.md
@@ -42,7 +42,7 @@ card.onActivate(function(environment){
       "show_url": "/people/159",
       "first_name": "Jolly",
       "last_name": "Fellow",
-      "email":  "jfellow@gmail.com",
+      "email":  "jfellow@company.com", // Extended Data Access required, else null
       "role": "admin",
       "department": "DEV",
       "avatar_path": "/images/icons/medium/person-avatar-admin.png"
@@ -115,7 +115,7 @@ Example user (note all arrays have been reduced to a single example item)
   "id": 2,
   "first_name": "Lucy",
   "last_name": "Chipotle",
-  "email": "lchipotle@gmail.com",
+  "email": "lchipotle@company.com", // Extended Data Access required, else null
   "role": "admin",
   "department": "IT",
   "avatar_path": "/images/icons/medium/person-avatar-admin.png",

--- a/source/documentation/cloud-apps/reference/helpdesk.md
+++ b/source/documentation/cloud-apps/reference/helpdesk.md
@@ -33,7 +33,7 @@ Name | Type | Description
 `search`|`object`| Search fields: `summary`, `description`.  See [Searching](/documentation/cloud-apps/api-basics.html#searching) documentation for more information.
 
 ##### Response
-```json
+```js
 {
   "meta": {
     "total_entries": 9,

--- a/source/documentation/cloud-apps/reference/helpdesk.md
+++ b/source/documentation/cloud-apps/reference/helpdesk.md
@@ -62,7 +62,7 @@ Name | Type | Description
 
 Example ticket (note all arrays have been reduced to a single example item):
 
-```json
+```js
 {
   "id": 53,
   "show_url": "/tickets/list/single_ticket/53",
@@ -114,7 +114,7 @@ Example ticket (note all arrays have been reduced to a single example item):
       "show_url": "/people/2"
     }
   ],
-  "comments": [
+  "comments": [  // Extended Data Access required, else not returned
     {
       "attachment_content_type": null,
       "attachment_name": null,

--- a/source/documentation/cloud-apps/reference/inventory.md
+++ b/source/documentation/cloud-apps/reference/inventory.md
@@ -33,7 +33,7 @@ Name | Type | Description
 `search`|`object`| Search fields: `manufacturer`, `model`, `name`, `operating_system`, `software.name`, `software.display_name`, `software.vendor`.  See [Searching](/documentation/cloud-apps/api-basics.html#searching) documentation for more information.
 
 ##### Response
-```json
+```js
 {
   "meta": {
     "total_entries": 166,
@@ -547,7 +547,7 @@ Name | Type | Description
 
 
 ##### Response
-```json
+```js
 {
   "meta": {
     "total_entries": 3096,

--- a/source/documentation/cloud-apps/reference/people.md
+++ b/source/documentation/cloud-apps/reference/people.md
@@ -53,7 +53,7 @@ Name | Type | Description
 
 Example person (note all arrays have been reduced to a single example item):
 
-```json
+```js
 {
   "id": 13,
   "first_name": "Alexia", // Extended Data Access required, else not returned

--- a/source/documentation/cloud-apps/reference/people.md
+++ b/source/documentation/cloud-apps/reference/people.md
@@ -25,7 +25,7 @@ Name | Type | Description
 `per_page`|`integer`| Number of entries per page. Must be between `1` and `100`.  Default: `30`
 
 ##### Response
-```json
+```js
 {
   "meta": {
     "total_entries": 166,

--- a/source/documentation/cloud-apps/reference/people.md
+++ b/source/documentation/cloud-apps/reference/people.md
@@ -56,11 +56,11 @@ Example person (note all arrays have been reduced to a single example item):
 ```json
 {
   "id": 13,
-  "first_name": "Alexia",
-  "last_name": "Rocoto",
+  "first_name": "Alexia", // Extended Data Access required, else not returned
+  "last_name": "Rocoto",  // Extended Data Access required, else not returned
   "role": "end_user",
   "department": "Finance",
-  "avatar_path": "/images/icons/medium/person-avatar-restricted.png",
+  "avatar_path": "/images/icons/medium/person-avatar-restricted.png", // Extended Data Access required, else not returned
   "show_url": "/people/13",
   "title": "",
   "location": "",

--- a/source/documentation/cloud-apps/reference/reporting.md
+++ b/source/documentation/cloud-apps/reference/reporting.md
@@ -41,7 +41,7 @@ Name | Type | Description
 `before` (optional)|`string`| Match all objects whose datetime field is `<=` the timestamp, provided in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
 
 ##### Response
-```json
+```js
 {
   "meta": {
     "total_entries": 9,


### PR DESCRIPTION
Email requires Extended Data Access in the Environment response,
otherwise email field is null.